### PR TITLE
Asset enqueuing improvements

### DIFF
--- a/includes/ucf-rss-common.php
+++ b/includes/ucf-rss-common.php
@@ -157,13 +157,15 @@ if ( ! function_exists( 'ucf_rss_has_shortcode' ) ) {
 if ( ! function_exists( 'ucf_rss_enqueue_assets' ) ) {
 	function ucf_rss_enqueue_assets() {
 		$has_shortcode = ucf_rss_has_shortcode();
+		$plugin_data   = get_plugin_data( UCF_RSS__PLUGIN_FILE, false, false );
+		$version       = $plugin_data['Version'];
 
 		// CSS
 		$include_css = UCF_RSS_Config::get_option_or_default( 'include_css' );
-		$css_deps = apply_filters( 'ucf_rss_style_deps', array() );
+		$css_deps    = apply_filters( 'ucf_rss_style_deps', array() );
 
 		if ( $include_css && $has_shortcode ) {
-			wp_enqueue_style( 'ucf_rss_css', plugins_url( 'static/css/ucf-rss.min.css', UCF_RSS__PLUGIN_FILE ), $css_deps, false, 'screen' );
+			wp_enqueue_style( 'ucf_rss_css', plugins_url( 'static/css/ucf-rss.min.css', UCF_RSS__PLUGIN_FILE ), $css_deps, $version, 'screen' );
 		}
 	}
 

--- a/includes/ucf-rss-common.php
+++ b/includes/ucf-rss-common.php
@@ -126,13 +126,43 @@ if ( !class_exists( 'UCF_RSS_Common' ) ) {
 
 }
 
+if ( ! function_exists( 'ucf_rss_has_shortcode' ) ) {
+	function ucf_rss_has_shortcode() {
+		$has_shortcode = false;
+		$strings       = array();
+		$obj           = get_queried_object();
+
+		if ( $obj ) {
+			switch ( get_class( $obj ) ) {
+				case 'WP_Post':
+					$strings[] = $obj->post_content;
+					break;
+				default:
+					break;
+			}
+		}
+
+		foreach ( $strings as $str ) {
+			if ( has_shortcode( $str, 'rss-feed' ) ) {
+				$has_shortcode = true;
+				break;
+			}
+		}
+
+		// Allow themes/plugins to override returned value:
+		return apply_filters( 'ucf_rss_has_shortcode', $has_shortcode, $obj );
+	}
+}
+
 if ( ! function_exists( 'ucf_rss_enqueue_assets' ) ) {
 	function ucf_rss_enqueue_assets() {
+		$has_shortcode = ucf_rss_has_shortcode();
+
 		// CSS
 		$include_css = UCF_RSS_Config::get_option_or_default( 'include_css' );
 		$css_deps = apply_filters( 'ucf_rss_style_deps', array() );
 
-		if ( $include_css ) {
+		if ( $include_css && $has_shortcode ) {
 			wp_enqueue_style( 'ucf_rss_css', plugins_url( 'static/css/ucf-rss.min.css', UCF_RSS__PLUGIN_FILE ), $css_deps, false, 'screen' );
 		}
 	}


### PR DESCRIPTION
- Added logic to ensure the main plugin stylesheet is only enqueued on pages/posts that include the [rss-feed] shortcode in the post content.  This logic can be overridden (e.g. to support other types of objects such as terms, and/or custom meta fields that support shortcodes) via the new `ucf_rss_has_shortcode` hook.
- Added the plugin version number to the enqueued stylesheet for cache-busting purposes.